### PR TITLE
make ApiError json serializable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 .php-cs-fixer.cache
 .phpunit.result.cache
 composer.lock
+.idea/

--- a/lib/Exceptions/ApiError.php
+++ b/lib/Exceptions/ApiError.php
@@ -2,7 +2,9 @@
 
 namespace AboutYou\Cloud\AdminApi\Exceptions;
 
-class ApiError
+use JsonSerializable;
+
+class ApiError implements JsonSerializable
 {
     /**
      * @var string
@@ -48,5 +50,17 @@ class ApiError
     public function getContext()
     {
         return $this->context;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'errorKey' => $this->errorKey,
+            'message' => $this->message,
+            'context' => $this->context,
+        ];
     }
 }


### PR DESCRIPTION
In order to log API errors to cloudwatch or datadog we need to make it JsonSerializable